### PR TITLE
Setup script to automatically configure custom project name

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,19 @@ opam install . --deps-only
 
 After that you'll need to rename all parts of the project to your new project name. Search for all occurances of `fsocaml` and `Fsocaml` and replace it with `myproject` and `Myproject` (or whatever you named your project).
 
-I'll add a script that automates this eventually.
+You can do this manually or by running
+
+```bash
+dune exec setup
+```
+
+which will use the name of the project folder as the project name, or
+
+```bash
+dune exec setup newproject
+```
+
+which can be used to give at a different name.
 
 ## Running the project
 

--- a/bin/config/dune
+++ b/bin/config/dune
@@ -1,3 +1,3 @@
 (library
-  (name fsoconf)
-  (libraries base))
+ (name fsoconf)
+ (libraries base))

--- a/bin/dune
+++ b/bin/dune
@@ -1,20 +1,38 @@
 (executable
-  (public_name fsocaml)
-  (name main)
-  (modules main)
-  (package fsocaml)
-  (libraries fsocaml fsoconf base stdio dream caqti-driver-postgresql caqti-lwt petrol models db dream-livereload))
+ (public_name fsocaml)
+ (name main)
+ (modules main)
+ (package fsocaml)
+ (libraries
+  fsocaml
+  fsoconf
+  base
+  stdio
+  dream
+  caqti-driver-postgresql
+  caqti-lwt
+  petrol
+  models
+  db
+  dream-livereload))
 
 (executable
-  (public_name migrate)
-  (name migrate)
-  (modules migrate)
-  (package fsocaml)
-  (libraries fsocaml fsoconf clap base core_unix stdio caqti-driver-postgresql))
+ (public_name migrate)
+ (name migrate)
+ (modules migrate)
+ (package fsocaml)
+ (libraries
+  fsocaml
+  fsoconf
+  clap
+  base
+  core_unix
+  stdio
+  caqti-driver-postgresql))
 
 (executable
-  (public_name setup)
-  (name setup)
-  (modules setup)
-  (package fsocaml)
-  (libraries clap core core_unix))
+ (public_name setup)
+ (name setup)
+ (modules setup)
+ (package fsocaml)
+ (libraries clap core core_unix))

--- a/bin/dune
+++ b/bin/dune
@@ -1,20 +1,20 @@
 (executable 
- (public_name fsocaml) 
- (name main) 
- (modules main) 
- (package fsocaml) 
+ (public_name fsocaml)
+ (name main)
+ (modules main)
+ (package fsocaml)
  (libraries fsocaml fsoconf base stdio dream caqti-driver-postgresql caqti-lwt petrol models db dream-livereload))
 
-(executable 
- (public_name migrate) 
- (name migrate) 
- (modules migrate) 
- (package fsocaml) 
+(executable
+ (public_name migrate)
+ (name migrate)
+ (modules migrate)
+ (package fsocaml)
  (libraries fsocaml fsoconf clap base core_unix stdio caqti-driver-postgresql))
 
-(executable 
- (public_name setup) 
- (name setup) 
- (modules setup) 
- (package fsocaml) 
+(executable
+ (public_name setup)
+ (name setup)
+ (modules setup)
+ (package fsocaml)
  (libraries clap core core_unix))

--- a/bin/dune
+++ b/bin/dune
@@ -1,13 +1,20 @@
-(executable
- (public_name fsocaml)
- (name main)
- (modules main)
- (package fsocaml)
+(executable 
+ (public_name fsocaml) 
+ (name main) 
+ (modules main) 
+ (package fsocaml) 
  (libraries fsocaml fsoconf base stdio dream caqti-driver-postgresql caqti-lwt petrol models db dream-livereload))
 
-(executable
-  (public_name migrate)
-  (name migrate)
-  (modules migrate)
-  (package fsocaml)
-  (libraries fsocaml fsoconf clap base core_unix stdio caqti-driver-postgresql))
+(executable 
+ (public_name migrate) 
+ (name migrate) 
+ (modules migrate) 
+ (package fsocaml) 
+ (libraries fsocaml fsoconf clap base core_unix stdio caqti-driver-postgresql))
+
+(executable 
+ (public_name setup) 
+ (name setup) 
+ (modules setup) 
+ (package fsocaml) 
+ (libraries clap core core_unix))

--- a/bin/dune
+++ b/bin/dune
@@ -1,20 +1,20 @@
-(executable 
- (public_name fsocaml)
- (name main)
- (modules main)
- (package fsocaml)
- (libraries fsocaml fsoconf base stdio dream caqti-driver-postgresql caqti-lwt petrol models db dream-livereload))
+(executable
+  (public_name fsocaml)
+  (name main)
+  (modules main)
+  (package fsocaml)
+  (libraries fsocaml fsoconf base stdio dream caqti-driver-postgresql caqti-lwt petrol models db dream-livereload))
 
 (executable
- (public_name migrate)
- (name migrate)
- (modules migrate)
- (package fsocaml)
- (libraries fsocaml fsoconf clap base core_unix stdio caqti-driver-postgresql))
+  (public_name migrate)
+  (name migrate)
+  (modules migrate)
+  (package fsocaml)
+  (libraries fsocaml fsoconf clap base core_unix stdio caqti-driver-postgresql))
 
 (executable
- (public_name setup)
- (name setup)
- (modules setup)
- (package fsocaml)
- (libraries clap core core_unix))
+  (public_name setup)
+  (name setup)
+  (modules setup)
+  (package fsocaml)
+  (libraries clap core core_unix))

--- a/bin/migrate.ml
+++ b/bin/migrate.ml
@@ -40,6 +40,7 @@ let execute_qry sql =
 (* Use the pool to execute queries *)
 
 let migrate_up_all () =
+  Core_unix.mkdir_p "migrations" |> ignore;
   let dir = Core_unix.opendir "migrations" in
   let dirs = collect_dirs dir in
   dirs

--- a/bin/migrate.ml
+++ b/bin/migrate.ml
@@ -65,8 +65,7 @@ let migrate_down_all () =
 let create_db () =
   let fn =
     let sql =
-      Stdlib.Format.sprintf {|CREATE DATABASE %s;|}
-        Fsoconf.db_params.database
+      Stdlib.Format.sprintf {|CREATE DATABASE %s;|} Fsoconf.db_params.database
     in
     let open Lwt_result.Syntax in
     let open Caqti_request.Infix in

--- a/bin/setup.ml
+++ b/bin/setup.ml
@@ -50,14 +50,12 @@ let sexp_patch s ~from ~into =
 
 
 let patch_sfile filename from into =
-  let sl = Sexp.load_sexps filename in
-  let f = (sexp_list_patch sl from into
+  let f =
+    Sexp.load_sexps filename
+    |> List.map ~f:(sexp_patch ~from ~into)
     |> List.map ~f:pp_sexp
-    |> String.concat ~sep:"\n"
-  ) in
-  Out_channel.with_file filename ~f:(fun file ->
-    Out_channel.output_string file f
-  )
+  in
+  Out_channel.write_lines filename f
 
 (** Scan lines in a source code file and replace all instances of `from` with `into`. *)
 let patch_mlfile filename ~from ~into =

--- a/bin/setup.ml
+++ b/bin/setup.ml
@@ -64,18 +64,12 @@ let patch_sfile filename from into =
   )
 
 (** Scan lines in a source code file and replace all instances of `from` with `into`. *)
-let patch_mlfile filename from into =
-  let f = (In_channel.with_file filename ~f:(fun file ->
-      In_channel.input_lines file
-    )
-    |> List.map ~f:(fun line ->
-      String.substr_replace_all line ~pattern:from ~with_:into
-    )
-    |> String.concat ~sep:"\n"
-  ) in
-  Out_channel.with_file filename ~f:(fun file ->
-    Out_channel.output_string file f
-  )
+let patch_mlfile filename ~from ~into =
+  let data =
+    In_channel.read_all filename
+    |> String.substr_replace_all ~pattern:from ~with_:into
+  in
+  Out_channel.write_all filename ~data
 
 
 let () =

--- a/bin/setup.ml
+++ b/bin/setup.ml
@@ -48,10 +48,6 @@ let sexp_patch s ~from ~into =
       ))
   in loop s true
 
-let sexp_list_patch sl from into =
-  List.map sl ~f:(fun s ->
-    sexp_patch s from into
-  )
 
 let patch_sfile filename from into =
   let sl = Sexp.load_sexps filename in

--- a/bin/setup.ml
+++ b/bin/setup.ml
@@ -77,10 +77,6 @@ let patch_mlfile filename from into =
     Out_channel.output_string file f
   )
 
-let capitalize str =
-  let first = String.get str 0 in
-  let rest = String.sub str ~pos:1 ~len:(String.length str - 1) in
-  Char.to_string (Char.uppercase first) ^ rest;;
 
 let () =
   Clap.description "Set up a new fsocaml project.";

--- a/bin/setup.ml
+++ b/bin/setup.ml
@@ -99,6 +99,6 @@ let () =
   List.iter dune_files ~f:(fun file -> patch_sfile file "fsocaml" projname');
 
   let projname'' = String.capitalize projname' in
-  patch_mlfile "bin/main.ml" "Fsocaml.Router.router" (projname'' ^ ".Router.router");
+  patch_mlfile "bin/main.ml" ~from:"Fsocaml.Router.router" ~into:(projname'' ^ ".Router.router");
 
   printf "%d files were patched.\n" ((List.length dune_files) + 1);

--- a/bin/setup.ml
+++ b/bin/setup.ml
@@ -27,7 +27,7 @@ let pp_sexp s =
     | Sexp.Atom a -> pp_atom a
     | Sexp.List l ->
         let nl = if f then "" else "\n" in
-        let prefix = sprintf "%s%s(" nl (indent i) in
+        let prefix = sprintf "%s%s(" nl (indent (i * 2)) in
         let ls = List.foldi l ~init:"" ~f:(fun j acc s'' -> 
           let sp = if j = 0 then "" else " " in
           acc ^ sp ^ (loop s'' (i + 1) false)

--- a/bin/setup.ml
+++ b/bin/setup.ml
@@ -102,7 +102,9 @@ let () =
   Clap.close ();
 
   let _ = Option.value dbname ~default:"fsocaml_dev" in
-  let projname' = String.lowercase (Option.value projname ~default:"fsocaml") in
+  let cwd = Core_unix.getcwd () |> String.split ~on:'/' |> List.last in
+  let default_projname = Option.value cwd ~default:"fsocaml" in
+  let projname' = String.lowercase (Option.value projname ~default:default_projname) in
 
   List.iter dune_files ~f:(fun file -> patch_sfile file "fsocaml" projname');
 

--- a/bin/setup.ml
+++ b/bin/setup.ml
@@ -104,7 +104,7 @@ let () =
 
   List.iter dune_files ~f:(fun file -> patch_sfile file "fsocaml" projname');
 
-  let projname'' = capitalize projname' in
+  let projname'' = String.capitalize projname' in
   patch_mlfile "bin/main.ml" "Fsocaml.Router.router" (projname'' ^ ".Router.router");
 
   printf "%d files were patched.\n" ((List.length dune_files) + 1);

--- a/bin/setup.ml
+++ b/bin/setup.ml
@@ -9,45 +9,59 @@
 
 open Core
 
-let dune_files = ["dune-project"; "test/dune"; "lib/dune"; "bin/dune"]
-
-let indent n =
-  String.init n ~f:(fun _ -> ' ')
+let dune_files = [ "dune-project"; "test/dune"; "lib/dune"; "bin/dune" ]
+let indent n = String.init n ~f:(fun _ -> ' ')
 
 let pp_atom a =
   if String.contains a ' ' then
     "\"" ^ a ^ "\""
-  else a
+  else
+    a
 
-(** Convert an S-expression into a pretty-printed string in the style
-    of a dune configuration file. *)
+(** Convert an S-expression into a pretty-printed string in the style of a dune
+    configuration file. *)
 let pp_sexp s =
   let rec loop s' i f =
     match s' with
     | Sexp.Atom a -> pp_atom a
     | Sexp.List l ->
-        let nl = if f then "" else "\n" in
+        let nl =
+          if f then
+            ""
+          else
+            "\n"
+        in
         let prefix = sprintf "%s%s(" nl (indent (i * 2)) in
-        let ls = List.foldi l ~init:"" ~f:(fun j acc s'' -> 
-          let sp = if j = 0 then "" else " " in
-          acc ^ sp ^ (loop s'' (i + 1) false)
-        ) in
+        let ls =
+          List.foldi l ~init:"" ~f:(fun j acc s'' ->
+              let sp =
+                if j = 0 then
+                  ""
+                else
+                  " "
+              in
+              acc ^ sp ^ loop s'' (i + 1) false)
+        in
         prefix ^ ls ^ ")"
-  in (loop s 0 true) ^ "\n"
+  in
+  loop s 0 true ^ "\n"
 
-(** Scan an S-expression and replace all instances of `from` with `into`,
-    except for labels (the first atom in a list). *)
+(** Scan an S-expression and replace all instances of `from` with `into`, except
+    for labels (the first atom in a list). *)
 let sexp_patch s ~from ~into =
-  let rec loop s' label  =
-    match s', label with
-    | Sexp.Atom a, false when (String.equal a from) -> Sexp.Atom into
+  let rec loop s' label =
+    match (s', label) with
+    | Sexp.Atom a, false when String.equal a from -> Sexp.Atom into
     | Sexp.Atom _, _ -> s'
-    | Sexp.List l, _ -> Sexp.List (List.mapi l ~f:(fun i s'' ->
-        if i = 0 then loop s'' true
-        else loop s'' false
-      ))
-  in loop s true
-
+    | Sexp.List l, _ ->
+        Sexp.List
+          (List.mapi l ~f:(fun i s'' ->
+               if i = 0 then
+                 loop s'' true
+               else
+                 loop s'' false))
+  in
+  loop s true
 
 let patch_sfile filename from into =
   let f =
@@ -57,7 +71,8 @@ let patch_sfile filename from into =
   in
   Out_channel.write_lines filename f
 
-(** Scan lines in a source code file and replace all instances of `from` with `into`. *)
+(** Scan lines in a source code file and replace all instances of `from` with
+    `into`. *)
 let patch_mlfile filename ~from ~into =
   let data =
     In_channel.read_all filename
@@ -65,22 +80,17 @@ let patch_mlfile filename ~from ~into =
   in
   Out_channel.write_all filename ~data
 
-
 let () =
   Clap.description "Set up a new fsocaml project.";
 
-  let dbname = 
-    Clap.optional_string
-    ~long: "dbname"
-    ~short: 'd'
-    ~placeholder: "DB_NAME" ()
-    ~description: "Database name (default: fsocaml_dev)"
+  let dbname =
+    Clap.optional_string ~long:"dbname" ~short:'d' ~placeholder:"DB_NAME" ()
+      ~description:"Database name (default: fsocaml_dev)"
   in
 
   let projname =
-    Clap.optional_string
-    ~placeholder: "PROJECT_NAME" ()
-    ~description: "Name of the fsocaml project (default: fsocaml)"
+    Clap.optional_string ~placeholder:"PROJECT_NAME" ()
+      ~description:"Name of the fsocaml project (default: fsocaml)"
   in
 
   Clap.close ();
@@ -88,11 +98,14 @@ let () =
   let _ = Option.value dbname ~default:"fsocaml_dev" in
   let cwd = Core_unix.getcwd () |> String.split ~on:'/' |> List.last in
   let default_projname = Option.value cwd ~default:"fsocaml" in
-  let projname' = String.lowercase (Option.value projname ~default:default_projname) in
+  let projname' =
+    String.lowercase (Option.value projname ~default:default_projname)
+  in
 
   List.iter dune_files ~f:(fun file -> patch_sfile file "fsocaml" projname');
 
   let projname'' = String.capitalize projname' in
-  patch_mlfile "bin/main.ml" ~from:"Fsocaml.Router.router" ~into:(projname'' ^ ".Router.router");
+  patch_mlfile "bin/main.ml" ~from:"Fsocaml.Router.router"
+    ~into:(projname'' ^ ".Router.router");
 
-  printf "%d files were patched.\n" ((List.length dune_files) + 1);
+  printf "%d files were patched.\n" (List.length dune_files + 1)

--- a/bin/setup.ml
+++ b/bin/setup.ml
@@ -1,0 +1,112 @@
+(** Setup script to customize a new fsocaml project.
+
+    Patches to `dune-project` and the various `dune` files are done by parsing
+    the S-expressions and replacing instances of `fsocaml` when it's in a
+    non-label position in the `Sexp.List`.
+
+    Source file patching (e.g. `bin/main.ml` is done by searching and replacing
+    references to the Fsocaml module itself. *)
+
+open Core
+
+let dune_files = ["dune-project"; "test/dune"; "lib/dune"; "bin/dune"]
+
+let indent n =
+  String.init n ~f:(fun _ -> ' ')
+
+let pp_atom a =
+  if String.contains a ' ' then
+    "\"" ^ a ^ "\""
+  else a
+
+(** Convert an S-expression into a pretty-printed string in the style
+    of a dune configuration file. *)
+let pp_sexp s =
+  let rec loop s' i f =
+    match s' with
+    | Sexp.Atom a -> pp_atom a
+    | Sexp.List l ->
+        let nl = if f then "" else "\n" in
+        let prefix = sprintf "%s%s(" nl (indent i) in
+        let ls = List.foldi l ~init:"" ~f:(fun j acc s'' -> 
+          let sp = if j = 0 then "" else " " in
+          acc ^ sp ^ (loop s'' (i + 1) false)
+        ) in
+        prefix ^ ls ^ ")"
+  in (loop s 0 true) ^ "\n"
+
+(** Scan an S-expression and replace all instances of `from` with `into`,
+    except for labels (the first atom in a list). *)
+let sexp_patch s from into =
+  let rec loop s' label  =
+    match s', label with
+    | Sexp.Atom a, false when (String.equal a from) -> Sexp.Atom into
+    | Sexp.Atom _, _ -> s'
+    | Sexp.List l, _ -> Sexp.List (List.mapi l ~f:(fun i s'' ->
+        if i = 0 then loop s'' true
+        else loop s'' false
+      ))
+  in loop s true
+
+let sexp_list_patch sl from into =
+  List.map sl ~f:(fun s ->
+    sexp_patch s from into
+  )
+
+let patch_sfile filename from into =
+  let sl = Sexp.load_sexps filename in
+  let f = (sexp_list_patch sl from into
+    |> List.map ~f:pp_sexp
+    |> String.concat ~sep:"\n"
+  ) in
+  Out_channel.with_file filename ~f:(fun file ->
+    Out_channel.output_string file f
+  )
+
+(** Scan lines in a source code file and replace all instances of `from` with `into`. *)
+let patch_mlfile filename from into =
+  let f = (In_channel.with_file filename ~f:(fun file ->
+      In_channel.input_lines file
+    )
+    |> List.map ~f:(fun line ->
+      String.substr_replace_all line ~pattern:from ~with_:into
+    )
+    |> String.concat ~sep:"\n"
+  ) in
+  Out_channel.with_file filename ~f:(fun file ->
+    Out_channel.output_string file f
+  )
+
+let capitalize str =
+  let first = String.get str 0 in
+  let rest = String.sub str ~pos:1 ~len:(String.length str - 1) in
+  Char.to_string (Char.uppercase first) ^ rest;;
+
+let () =
+  Clap.description "Set up a new fsocaml project.";
+
+  let dbname = 
+    Clap.optional_string
+    ~long: "dbname"
+    ~short: 'd'
+    ~placeholder: "DB_NAME" ()
+    ~description: "Database name (default: fsocaml_dev)"
+  in
+
+  let projname =
+    Clap.optional_string
+    ~placeholder: "PROJECT_NAME" ()
+    ~description: "Name of the fsocaml project (default: fsocaml)"
+  in
+
+  Clap.close ();
+
+  let _ = Option.value dbname ~default:"fsocaml_dev" in
+  let projname' = String.lowercase (Option.value projname ~default:"fsocaml") in
+
+  List.iter dune_files ~f:(fun file -> patch_sfile file "fsocaml" projname');
+
+  let projname'' = capitalize projname' in
+  patch_mlfile "bin/main.ml" "Fsocaml.Router.router" (projname'' ^ ".Router.router");
+
+  printf "%d files were patched.\n" ((List.length dune_files) + 1);

--- a/bin/setup.ml
+++ b/bin/setup.ml
@@ -37,7 +37,7 @@ let pp_sexp s =
 
 (** Scan an S-expression and replace all instances of `from` with `into`,
     except for labels (the first atom in a list). *)
-let sexp_patch s from into =
+let sexp_patch s ~from ~into =
   let rec loop s' label  =
     match s', label with
     | Sexp.Atom a, false when (String.equal a from) -> Sexp.Atom into

--- a/lib/controllers/dune
+++ b/lib/controllers/dune
@@ -1,4 +1,5 @@
 (library
  (name controllers)
  (libraries dream views ppx_dream_eml models)
- (preprocess (pps ppx_dream_eml lwt_ppx)))
+ (preprocess
+  (pps ppx_dream_eml lwt_ppx)))

--- a/lib/db/dune
+++ b/lib/db/dune
@@ -1,3 +1,3 @@
 (library
-  (name db)
-  (libraries dream petrol))
+ (name db)
+ (libraries dream petrol))

--- a/lib/models/dune
+++ b/lib/models/dune
@@ -1,4 +1,5 @@
 (library
  (name models)
  (libraries dream base petrol db safepass)
- (preprocess (pps lwt_ppx ppx_combust)))
+ (preprocess
+  (pps lwt_ppx ppx_combust)))

--- a/lib/views/dune
+++ b/lib/views/dune
@@ -1,4 +1,5 @@
 (library
  (name views)
  (libraries dream layouts)
- (preprocess (pps ppx_dream_eml)))
+ (preprocess
+  (pps ppx_dream_eml)))

--- a/ppx-combust/dune
+++ b/ppx-combust/dune
@@ -2,14 +2,16 @@
  (name pp)
  (modules pp)
  (libraries ppxlib)
- (preprocess (pps ppxlib.metaquot ppx_combust)))
+ (preprocess
+  (pps ppxlib.metaquot ppx_combust)))
 
 (library
  (name ppx_combust)
  (kind ppx_deriver)
  (modules combust)
  (package ppx_combust)
- (flags (:standard -w -27))
+ (flags
+  (:standard -w -27))
  (libraries ppxlib base fmt ppx_deriving.api)
  (preprocess
   (pps ppxlib.metaquot)))


### PR DESCRIPTION
Added a basic setup script that automatically changes the project name from `fsocaml` to a custom name in the `dune` configuration files and source files.

`dune exec setup` picks the project name to be the same as the leaf node of the project folder. `dune exec setup myproject` allows the user to pick a custom project name.

The script processes the S-expressions in the dune files in case one wants to extend setup to further manipulation of these files. I also thought it could be nice to next make the setup script interactive with prompts and sensible defaults to give the user a quick way to customize the project, e.g. select dev database user names and passwords and opt to automatically remove the `.git` folder.

The PR also includes a small bugfix in `migrate.ml` where `migrate up` would fail if the `migrations` dir doesn't yet exist.