### PR TITLE
Random token

### DIFF
--- a/README.md
+++ b/README.md
@@ -366,13 +366,7 @@ type t = {
 [@@deriving combust ~name:"users_tokens"]
 
 let rand_str len =
-  Random.self_init ();
-  let buf = Buffer.create len in
-  for _ = 0 to len - 1 do
-    Buffer.add_char buf (Char.chr (32 + Random.int 94))
-  done;
-
-  String.of_bytes (Buffer.to_bytes buf)
+  String.init len (fun _ -> Char.chr (33 + Random.int 94))
 
 let create user_id db =
   Query.insert ~into:table

--- a/README.md
+++ b/README.md
@@ -364,9 +364,9 @@ type t = {
   token : string;
 }
 [@@deriving combust ~name:"users_tokens"]
+let _ = Random.self_init ()
 
 let rand_str len =
-  Random.self_init ();
   String.init len (fun _ -> Char.chr (33 + Random.int 94))
 
 let create user_id db =

--- a/README.md
+++ b/README.md
@@ -366,6 +366,7 @@ type t = {
 [@@deriving combust ~name:"users_tokens"]
 
 let rand_str len =
+  Random.self_init ();
   String.init len (fun _ -> Char.chr (33 + Random.int 94))
 
 let create user_id db =

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -15,6 +15,8 @@ let () =
   if Poly.( = ) Fsoconf.env Fsoconf.Dev then
     Dream.initialize_log ~level:`Debug ();
 
+  Random.self_init ();
+
   Dream.run ~interface:Fsoconf.host ~port:Fsoconf.port ~adjust_terminal:false
     ~error_handler:Dream.debug_error_handler
   @@ Dream.set_secret Fsoconf.secret_key

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -15,8 +15,6 @@ let () =
   if Poly.( = ) Fsoconf.env Fsoconf.Dev then
     Dream.initialize_log ~level:`Debug ();
 
-  Random.self_init ();
-
   Dream.run ~interface:Fsoconf.host ~port:Fsoconf.port ~adjust_terminal:false
     ~error_handler:Dream.debug_error_handler
   @@ Dream.set_secret Fsoconf.secret_key


### PR DESCRIPTION
I think the token generation could be made a bit simpler in the tutorial, and perhaps a bit more secure (unless I misunderstood something in the original code).

I'd suggest using `String.init` directly instead of the intermediate buffer. Also, picking a range offset of 33 rather than 32 avoids spaces in the token. I assume we don't have anything personal against Char.chr 126 (~) either, so it's now included.

I'd also tentatively suggest moving `Random.self_init` out to app initialization. High-frequency re-seeding of an RNG is generally not recommended – depending on the seed source you could run out of entropy (causing delays) or even see repeat generation of the same random numbers on more naive systems. I assume that Dream will just keep generating RNs from the initial domain that was seeded.

This also makes the tutorial example a bit simpler.