### PR TITLE
Add missing dependencies

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -19,7 +19,7 @@
  (name fsocaml)
  (synopsis "A short synopsis")
  (description "A longer description")
- (depends ocaml dune dream dream-livereload (petrol (= 1.2.4)) ppx_dream_eml)
+ (depends ocaml dune dream dream-livereload (petrol (= 1.2.4)) ppx_dream_eml core_unix clap caqti-driver-postgresql safepass ppx_deriving letters)
  (tags
   (topics "to describe" your project)))
 
@@ -28,6 +28,6 @@
  (authors "TJ DeVries" "Petri-Johan Last")
  (maintainers "TJ DeVries" "Petri-Johan Last")
  (synopsis "Generate boilerplate stuff for petrol to go zoom zoom")
- (depends ocaml ppxlib))
+ (depends ocaml ppxlib ppx_deriving))
 
 ; See the complete stanza docs at https://dune.readthedocs.io/en/stable/dune-files.html#dune-project

--- a/fsocaml.opam
+++ b/fsocaml.opam
@@ -16,6 +16,12 @@ depends: [
   "dream-livereload"
   "petrol" {= "1.2.4"}
   "ppx_dream_eml"
+  "core_unix"
+  "clap"
+  "caqti-driver-postgresql"
+  "safepass"
+  "ppx_deriving"
+  "letters"
   "odoc" {with-doc}
 ]
 build: [
@@ -34,5 +40,5 @@ build: [
 ]
 dev-repo: "git+https://github.com/username/reponame.git"
 pin-depends: [
-  ["petrol.1.2.4" "https://github.com/pjlast/petrol.git#1.2.4"]
+  ["petrol.1.2.4" "git+https://github.com/pjlast/petrol.git#1.2.4"]
 ]

--- a/fsocaml.opam.template
+++ b/fsocaml.opam.template
@@ -1,3 +1,3 @@
 pin-depends: [
-  ["petrol.1.2.4" "https://github.com/pjlast/petrol.git#1.2.4"]
+  ["petrol.1.2.4" "git+https://github.com/pjlast/petrol.git#1.2.4"]
 ]

--- a/ppx_combust.opam
+++ b/ppx_combust.opam
@@ -11,6 +11,7 @@ depends: [
   "dune" {>= "3.11"}
   "ocaml"
   "ppxlib"
+  "ppx_deriving"
   "odoc" {with-doc}
 ]
 build: [


### PR DESCRIPTION
Closes #3 

A fresh clone of FSOCaml had some missing dependencies due to the dependencies already existing on my system. This PR adds all of the missing dependencies and a fresh install was tested using a local opam switch.